### PR TITLE
Fixed an unmarshalling issue

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -334,15 +334,15 @@ type clientText struct {
 
 type clientPresence struct {
 	XMLName xml.Name `xml:"jabber:client presence"`
-	From    string   `xml:",attr"`
-	Id      string   `xml:",attr"`
-	To      string   `xml:",attr"`
-	Type    string   `xml:",attr"` // error, probe, subscribe, subscribed, unavailable, unsubscribe, unsubscribed
-	Lang    string   `xml:",attr"`
+	From    string   `xml:"from,attr"`
+	Id      string   `xml:"id,attr"`
+	To      string   `xml:"to,attr"`
+	Type    string   `xml:"type,attr"` // error, probe, subscribe, subscribed, unavailable, unsubscribe, unsubscribed
+	Lang    string   `xml:"lang,attr"`
 
-	Show     string // away, chat, dnd, xa
-	Status   string // sb []clientText
-	Priority string
+	Show     string  `xml:"show,attr"`// away, chat, dnd, xa
+	Status   string  `xml:"status,attr"`// sb []clientText
+	Priority string  `xml:"priority,attr"`
 	Error    *clientError
 }
 


### PR DESCRIPTION
In an issue I left on your tracker, I mentioned that next an Recv were returning empty structs despite not having any errors. In #go-nuts I found out this is because the xml comment strings were incorrect so xml.Decoder.DecodeElement was trying to match, eg, "body" tags to a field "body" but only "Body" existed. One can now receive messages. I'm sure similar fixes need to be made to other tags but this is what I needed and we can fix the others later.
