### PR TITLE
Remove a declared variable that isn't used. So the library will compile.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -241,7 +241,6 @@ func (c *Client) init(o *Options) error {
 	if len(a) != 2 {
 		return errors.New("xmpp: invalid username (want user@domain): " + o.User)
 	}
-	user := a[0]
 	domain := a[1]
 
 	// Declare intent to be a jabber client.


### PR DESCRIPTION
go build was complaing that user was defined but never used... so I removed it.  

Tested and my bot based on the library is working w/out the var... and reading the code it seems the compiler is correct, it's declared but never used.  
