### PR TITLE
add starttls support

### DIFF
--- a/xmpp_muc.go
+++ b/xmpp_muc.go
@@ -17,11 +17,14 @@ const (
 )
 
 // xep-0045 7.2
-func (c *Client) JoinMUC(jid string) {
-	fmt.Fprintf(c.conn, "<presence to='%s'>\n"+
+func (c *Client) JoinMUC(jid, nick string) {
+	if nick == "" {
+		nick = c.jid
+	}
+	fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
 		"<x xmlns='%s' />\n"+
 		"</presence>",
-		xmlEscape(jid), nsMUC)
+		xmlEscape(jid), xmlEscape(nick), nsMUC)
 }
 
 // xep-0045 7.14


### PR DESCRIPTION
StartTLS support introduced, so lib can be used to communicate with
servers that wants to `<starttls/>` before real TLS session begins.

`StartTLS = true` and `NoTLS = false` options should be both explicitly
specified to enable delayed TLS session to begin.

Also, added a way to specify nickname when joining MUC.

Also, added 'NoVerifyTLSHost' option to skip cert check for broken
servers.

Possible fix for: #10.
