### PR TITLE
Only check the certificate's host name if InsecureSkipVerify is not set.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -176,8 +176,14 @@ func (o Options) NewClient() (*Client, error) {
 		if strings.LastIndex(o.Host, ":") > 0 {
 			host = host[:strings.LastIndex(o.Host, ":")]
 		}
-		if err = tlsconn.VerifyHostname(host); err != nil {
-			return nil, err
+		insecureSkipVerify := DefaultConfig.InsecureSkipVerify
+		if o.TLSConfig != nil {
+			insecureSkipVerify = o.TLSConfig.InsecureSkipVerify
+		}
+		if !insecureSkipVerify {
+			if err = tlsconn.VerifyHostname(host); err != nil {
+				return nil, err
+			}
 		}
 		client.conn = tlsconn
 	}


### PR DESCRIPTION
If we don't want to check the certificate, then we don't need to check the hostname either. Other code calling VerifyHostname seems to wrap the code into a similar check.
