### PR TITLE
fix DefaultConfig.ServerName not set when func NewClient(host...) is used

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -168,6 +168,7 @@ func (o Options) NewClient() (*Client, error) {
 		if o.TLSConfig != nil {
 			tlsconn = tls.Client(c, o.TLSConfig)
 		} else {
+			DefaultConfig.ServerName = strings.Split(o.User, "@")[1]
 			tlsconn = tls.Client(c, &DefaultConfig)
 		}
 		if err = tlsconn.Handshake(); err != nil {


### PR DESCRIPTION
I get "tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config" trying to connect to Google GCM CCS server. This happens for all servers that don't support STARTTLS as `ServerName` in only set in function `startTlsIfRequired` and not in `NewClient` function.
