### PR TITLE
do not crash on failed connect

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -224,7 +224,11 @@ func NewClientNoTLS(host, user, passwd string, debug bool) (*Client, error) {
 }
 
 func (c *Client) Close() error {
-	return c.conn.Close()
+	if c.conn != (*tls.Conn)(nil) {
+		return c.conn.Close()
+	} else {
+		return nil
+	}
 }
 
 func saslDigestResponse(username, realm, passwd, nonce, cnonceStr,


### PR DESCRIPTION
Connection can fail here, and in case of it can't validate TLS certificate `client.Close` will panic.
https://github.com/seletskiy/go-xmpp/blob/a60980a550232f760b66c9238ca4daa0d5dd50db/xmpp.go#L193
