### PR TITLE
fix eternal cycle with malicious xml packet

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -685,7 +685,7 @@ type clientError struct {
 func nextStart(p *xml.Decoder) (xml.StartElement, error) {
 	for {
 		t, err := p.Token()
-		if err != nil && err != io.EOF {
+		if err != nil && err != io.EOF || t == nil {
 			return xml.StartElement{}, err
 		}
 		switch t := t.(type) {


### PR DESCRIPTION
Hello.

I'm using this library for my xmpp-service, but I get a trouble, app become consume 100% cpu when I have a problems with net.

After recompiling with debug tables, I'm attached to process with gdb. And when process become consume 100% cpu, I found the problem in one eternal cycle.

Trace:
```
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
(gdb) n
      switch t := t.(type) {
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
(gdb) n
      switch t := t.(type) {
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
(gdb) n
      switch t := t.(type) {
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
(gdb) n
      switch t := t.(type) {
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
(gdb) n
      switch t := t.(type) {
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
(gdb) n
      switch t := t.(type) {
(gdb) n
      t, err := p.Token()
(gdb) n
      if err != nil && err != io.EOF {
```

Showing local variables:
```
(gdb) info locals
t = {0x0, data = 0x0}
err = {0x7f6eb37bf940, data = 0xc20800a090}
t = {Space = 0x7f6eb37b66e8 "", Local = 0x0 <error: Cannot access memory at
address 0x0>}, Attr = {array = 0x3, len = 4321220, cap = 833358110040}}
```
How you can see, `t` (token) is equal to `nil`.
So I check it, and `encoding/xml Decoder.Token()` can return `nil, io.EOF`.
