### PR TITLE
Ping: return errors

### DIFF
--- a/xmpp_ping.go
+++ b/xmpp_ping.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 )
 
-func (c *Client) PingC2S(jid, server string) {
-	fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
+func (c *Client) PingC2S(jid, server string) error {
+	_, err := fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",
 		xmlEscape(jid), xmlEscape(server))
+	return err
 }
 
-func (c *Client) PingS2S(fromServer, toServer string) {
-	fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='s2s1' type='get'>\n"+
+func (c *Client) PingS2S(fromServer, toServer string) error {
+	_, err := fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='s2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",
 		xmlEscape(fromServer), xmlEscape(toServer))
+	return err
 }


### PR DESCRIPTION
Hey!

With this patch error codes are returned for the PingC2S and PingS2S methods. This is necessary to build highly available and fault tolerant services...

Cheers, Philip