### PR TITLE
Add Chat.OtherElem member to keep descendant elements in message element

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -536,12 +536,13 @@ func (c *Client) IsEncrypted() bool {
 
 // Chat is an incoming or outgoing XMPP chat message.
 type Chat struct {
-	Remote string
-	Type   string
-	Text   string
-	Roster Roster
-	Other  []string
-	Stamp  time.Time
+	Remote    string
+	Type      string
+	Text      string
+	Roster    Roster
+	Other     []string
+	OtherElem []XMLElement
+	Stamp     time.Time
 }
 
 type Roster []Contact
@@ -584,11 +585,12 @@ func (c *Client) Recv() (stanza interface{}, err error) {
 				v.Delay.Stamp,
 			)
 			chat := Chat{
-				Remote: v.From,
-				Type:   v.Type,
-				Text:   v.Body,
-				Other:  v.Other,
-				Stamp:  stamp,
+				Remote:    v.From,
+				Type:      v.Type,
+				Text:      v.Body,
+				Other:     v.OtherStrings(),
+				OtherElem: v.Other,
+				Stamp:     stamp,
 			}
 			return chat, nil
 		case *clientQuery:
@@ -720,9 +722,44 @@ type clientMessage struct {
 	Thread  string `xml:"thread"`
 
 	// Any hasn't matched element
-	Other []string `xml:",any"`
+	Other []XMLElement `xml:",any"`
 
 	Delay Delay `xml:"delay"`
+}
+
+func (m *clientMessage) OtherStrings() []string {
+	a := make([]string, len(m.Other))
+	for i, e := range m.Other {
+		a[i] = e.String()
+	}
+	return a
+}
+
+type XMLElement struct {
+	XMLName  xml.Name
+	InnerXML string `xml:",innerxml"`
+}
+
+func (e *XMLElement) String() string {
+	r := bytes.NewReader([]byte(e.InnerXML))
+	d := xml.NewDecoder(r)
+	var buf bytes.Buffer
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			break
+		}
+		switch v := tok.(type) {
+		case xml.StartElement:
+			err = d.Skip()
+		case xml.CharData:
+			_, err = buf.Write(v)
+		}
+		if err != nil {
+			break
+		}
+	}
+	return buf.String()
 }
 
 type Delay struct {

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -57,7 +57,7 @@ func (*testConn) SetWriteDeadline(time.Time) error {
 var text = strings.TrimSpace(`
 <message xmlns="jabber:client" id="3" type="error" to="123456789@gcm.googleapis.com/ABC">
 	<gcm xmlns="google:mobile:data">
-		{"random": "text"}
+		{"random": "&lt;text&gt;"}
 	</gcm>
 	<error code="400" type="modify">
 		<bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
@@ -80,8 +80,23 @@ func TestStanzaError(t *testing.T) {
 	chat := Chat{
 		Type: "error",
 		Other: []string{
-			"\n\t\t{\"random\": \"text\"}\n\t",
+			"\n\t\t{\"random\": \"<text>\"}\n\t",
 			"\n\t\t\n\t\t\n\t",
+		},
+		OtherElem: []XMLElement{
+			XMLElement{
+				XMLName:  xml.Name{Space: "google:mobile:data", Local: "gcm"},
+				InnerXML: "\n\t\t{\"random\": \"&lt;text&gt;\"}\n\t",
+			},
+			XMLElement{
+				XMLName: xml.Name{Space: "jabber:client", Local: "error"},
+				InnerXML: `
+		<bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
+		<text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">
+			InvalidJson: JSON_PARSING_ERROR : Missing Required Field: message_id\n
+		</text>
+	`,
+			},
 		},
 	}
 	if !reflect.DeepEqual(v, chat) {

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -1,0 +1,90 @@
+package xmpp
+
+import (
+	"bytes"
+	"encoding/xml"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type localAddr struct{}
+
+func (a *localAddr) Network() string {
+	return "tcp"
+}
+
+func (addr *localAddr) String() string {
+	return "localhost:5222"
+}
+
+type testConn struct {
+	*bytes.Buffer
+}
+
+func tConnect(s string) net.Conn {
+	var conn testConn
+	conn.Buffer = bytes.NewBufferString(s)
+	return &conn
+}
+
+func (*testConn) Close() error {
+	return nil
+}
+
+func (*testConn) LocalAddr() net.Addr {
+	return &localAddr{}
+}
+
+func (*testConn) RemoteAddr() net.Addr {
+	return &localAddr{}
+}
+
+func (*testConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (*testConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (*testConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+var text = strings.TrimSpace(`
+<message xmlns="jabber:client" id="3" type="error" to="123456789@gcm.googleapis.com/ABC">
+	<gcm xmlns="google:mobile:data">
+		{"random": "text"}
+	</gcm>
+	<error code="400" type="modify">
+		<bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
+		<text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">
+			InvalidJson: JSON_PARSING_ERROR : Missing Required Field: message_id\n
+		</text>
+	</error>
+</message>
+`)
+
+func TestStanzaError(t *testing.T) {
+	var c Client
+	c.conn = tConnect(text)
+	c.p = xml.NewDecoder(c.conn)
+	v, err := c.Recv()
+	if err != nil {
+		t.Fatalf("Recv() = %v", err)
+	}
+
+	chat := Chat{
+		Type: "error",
+		Other: []string{
+			"\n\t\t{\"random\": \"text\"}\n\t",
+			"\n\t\t\n\t\t\n\t",
+		},
+	}
+	if !reflect.DeepEqual(v, chat) {
+		t.Errorf("Recv() = %#v; want %#v", v, chat)
+	}
+}


### PR DESCRIPTION
fixed #48 

`Chat.Other` presents child element's text but it don't include grandchild elements.
Though this PR isn't perfect, it is useful for stanza error.

known limitation is:

* `Chat.OtherElem` don't present attributes of child element of message element.