### PR TITLE
Fix neglected io.EOF handling

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -833,7 +833,7 @@ type rosterItem struct {
 func nextStart(p *xml.Decoder) (xml.StartElement, error) {
 	for {
 		t, err := p.Token()
-		if err != nil && err != io.EOF || t == nil {
+		if err != nil || t == nil {
 			return xml.StartElement{}, err
 		}
 		switch t := t.(type) {

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -3,6 +3,7 @@ package xmpp
 import (
 	"bytes"
 	"encoding/xml"
+	"io"
 	"net"
 	"reflect"
 	"strings"
@@ -101,5 +102,15 @@ func TestStanzaError(t *testing.T) {
 	}
 	if !reflect.DeepEqual(v, chat) {
 		t.Errorf("Recv() = %#v; want %#v", v, chat)
+	}
+}
+
+func TestEOFError(t *testing.T) {
+	var c Client
+	c.conn = tConnect("")
+	c.p = xml.NewDecoder(c.conn)
+	_, err := c.Recv()
+	if err != io.EOF {
+		t.Errorf("Recv() did not return io.EOF on end of input stream")
 	}
 }


### PR DESCRIPTION
This was probably catched in most cases after commit 9dd92e1, but was at best misleading as it suggested that the end of input stream signal from xml.Decoder was intentionally ignored.

Ref mattn/go-xmpp#28