### PR TITLE
Add id field to outgoing chat messages

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -31,6 +31,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/satori/go.uuid"
 )
 
 const (
@@ -660,8 +662,11 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	if chat.Thread != `` {
 		thdtext = `<thread>` + xmlEscape(chat.Thread) + `</thread>`
 	}
-	return fmt.Fprintf(c.conn, "<message to='%s' type='%s' xml:lang='en'>"+subtext+"<body>%s</body>"+thdtext+"</message>",
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), xmlEscape(chat.Text))
+
+	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext + thdtext + "<body>%s</body>" + "</message>"
+
+	return fmt.Fprintf(c.conn, stanza,
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), uuid.NewV1().String(), xmlEscape(chat.Text))
 }
 
 // SendOrg sends the original text without being wrapped in an XMPP message stanza.
@@ -756,7 +761,7 @@ type saslFailure struct {
 type bindBind struct {
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-bind bind"`
 	Resource string
-	Jid      string `xml:"jid"`
+	Jid      string   `xml:"jid"`
 }
 
 // RFC 3921  B.1  jabber:client
@@ -836,7 +841,8 @@ type clientPresence struct {
 	Error    *clientError
 }
 
-type clientIQ struct { // info/query
+type clientIQ struct {
+	// info/query
 	XMLName xml.Name `xml:"jabber:client iq"`
 	From    string   `xml:"from,attr"`
 	ID      string   `xml:"id,attr"`

--- a/xmpp.go
+++ b/xmpp.go
@@ -31,8 +31,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/satori/go.uuid"
 )
 
 const (
@@ -666,7 +664,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext + thdtext + "<body>%s</body>" + "</message>"
 
 	return fmt.Fprintf(c.conn, stanza,
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), uuid.NewV1().String(), xmlEscape(chat.Text))
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce(), xmlEscape(chat.Text))
 }
 
 // SendOrg sends the original text without being wrapped in an XMPP message stanza.


### PR DESCRIPTION
I have found that outgoing chat messages are not being properly forwarded to clients by ejabberd - they get archived but not delivered.

The solution was to add an id field to the chat message - then everything worked perfectly. I note that id is RECOMMENDED by the xmpp spec so this does not make complete sense - but this PR provides a fix that works for me and maybe others.

For simplicity I have used existing cnonce function which seems to provide a suitable random string