### PR TITLE
Add 'id' to outgoing message using cnonce 

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -31,6 +31,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/satori/go.uuid"
 )
 
 const (
@@ -660,8 +662,11 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	if chat.Thread != `` {
 		thdtext = `<thread>` + xmlEscape(chat.Thread) + `</thread>`
 	}
-	return fmt.Fprintf(c.conn, "<message to='%s' type='%s' xml:lang='en'>"+subtext+"<body>%s</body>"+thdtext+"</message>",
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), xmlEscape(chat.Text))
+
+	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext + thdtext + "<body>%s</body>" + "</message>"
+
+	return fmt.Fprintf(c.conn, stanza,
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), uuid.NewV1().String(), xmlEscape(chat.Text))
 }
 
 // SendOrg sends the original text without being wrapped in an XMPP message stanza.
@@ -756,7 +761,7 @@ type saslFailure struct {
 type bindBind struct {
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-bind bind"`
 	Resource string
-	Jid      string `xml:"jid"`
+	Jid      string   `xml:"jid"`
 }
 
 // RFC 3921  B.1  jabber:client
@@ -836,7 +841,8 @@ type clientPresence struct {
 	Error    *clientError
 }
 
-type clientIQ struct { // info/query
+type clientIQ struct {
+	// info/query
 	XMLName xml.Name `xml:"jabber:client iq"`
 	From    string   `xml:"from,attr"`
 	ID      string   `xml:"id,attr"`

--- a/xmpp.go
+++ b/xmpp.go
@@ -661,7 +661,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 		thdtext = `<thread>` + xmlEscape(chat.Thread) + `</thread>`
 	}
 
-	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext + thdtext + "<body>%s</body>" + "</message>"
+	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext +  "<body>%s</body>" + thdtext + "</message>"
 
 	return fmt.Fprintf(c.conn, stanza,
 		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce(), xmlEscape(chat.Text))

--- a/xmpp.go
+++ b/xmpp.go
@@ -31,8 +31,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/satori/go.uuid"
 )
 
 const (
@@ -666,7 +664,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext + thdtext + "<body>%s</body>" + "</message>"
 
 	return fmt.Fprintf(c.conn, stanza,
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), uuid.NewV1().String(), xmlEscape(chat.Text))
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce(), xmlEscape(chat.Text))
 }
 
 // SendOrg sends the original text without being wrapped in an XMPP message stanza.


### PR DESCRIPTION
Providing an 'id' in chat stanza is RECOMMENDED by xmpp spec and I found messages were being archived but not delivered by my otherwise vanilla ejabberd server. 

I would request the patch is used so that every sent message has a unique id - as this is common in other clients and at least in my use case makes the library work!

(sorry for messing up the PR previously - have double checked this time..)