### PR TITLE
Add xml attribute support for XMLElement

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -1001,6 +1001,7 @@ func (m *clientMessage) OtherStrings() []string {
 
 type XMLElement struct {
 	XMLName  xml.Name
+	Attr     []xml.Attr `xml:",any,attr"` // Save the attributes of the xml element
 	InnerXML string `xml:",innerxml"`
 }
 

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -87,10 +87,12 @@ func TestStanzaError(t *testing.T) {
 		OtherElem: []XMLElement{
 			XMLElement{
 				XMLName:  xml.Name{Space: "google:mobile:data", Local: "gcm"},
+				Attr:     []xml.Attr{xml.Attr{Name:xml.Name{Space:"", Local:"xmlns"}, Value:"google:mobile:data"}},
 				InnerXML: "\n\t\t{\"random\": \"&lt;text&gt;\"}\n\t",
 			},
 			XMLElement{
 				XMLName: xml.Name{Space: "jabber:client", Local: "error"},
+				Attr:    []xml.Attr{xml.Attr{Name:xml.Name{Space:"", Local:"code"}, Value:"400"},xml.Attr{Name:xml.Name{Space:"", Local:"type"}, Value:"modify"}},
 				InnerXML: `
 		<bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
 		<text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">


### PR DESCRIPTION
# PR to add xml attribute support for XMLElement

**Problem:**
OtherElem list has xml elements that are not part of the basic xmpp stanza. While go-xmpp collects sub elements into innerXML string correctly, it loses xml attributes for the outermost xml element.

**Solution:**
Add attribute collection to XMLElement and let Go xml parsing do the work.

**Side effects:**
Should be minimal. XMLElement is used only in a few places and an added interface member does not affect any of the other actions it is used in.

**Benefits:**
Possible to work with the attributes of the containing Other Element. Anybody who adds their own tags (like IoT devices) will have an easier time if some of the attributes aren't lost.

**Changes:**
1. Added line to XMLElement definition to include attributes and give the xml parser info to parse the attributes
2. Added support to xmpp_test.go to test for the missing attributes. All tests pass now.

