### PR TITLE
Print sent stanzas in debug mode.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -59,7 +59,7 @@ func getCookie() Cookie {
 	return Cookie(binary.LittleEndian.Uint64(buf[:]))
 }
 
-// Client holds XMPP connection opitons
+// Client holds XMPP connection options
 type Client struct {
 	conn   net.Conn // connection to server
 	jid    string   // Jabber ID for our connection

--- a/xmpp.go
+++ b/xmpp.go
@@ -47,6 +47,7 @@ var DefaultConfig = &tls.Config{}
 
 // DebugWriter is the writer used to write debugging output to.
 var DebugWriter io.Writer = os.Stderr
+var StanzaWriter io.Writer
 
 // Cookie is a unique XMPP session identifier
 type Cookie uint64
@@ -368,7 +369,7 @@ func (c *Client) init(o *Options) error {
 		foundAnonymous := false
 		for _, m := range f.Mechanisms.Mechanism {
 			if m == "ANONYMOUS" {
-				fmt.Fprintf(c.conn, "<auth xmlns='%s' mechanism='ANONYMOUS' />\n", nsSASL)
+				fmt.Fprintf(StanzaWriter, "<auth xmlns='%s' mechanism='ANONYMOUS' />\n", nsSASL)
 				foundAnonymous = true
 				break
 			}
@@ -486,9 +487,9 @@ func (c *Client) init(o *Options) error {
 
 	// Send IQ message asking to bind to the local user name.
 	if o.Resource == "" {
-		fmt.Fprintf(c.conn, "<iq type='set' id='%x'><bind xmlns='%s'></bind></iq>\n", cookie, nsBind)
+		fmt.Fprintf(StanzaWriter, "<iq type='set' id='%x'><bind xmlns='%s'></bind></iq>\n", cookie, nsBind)
 	} else {
-		fmt.Fprintf(c.conn, "<iq type='set' id='%x'><bind xmlns='%s'><resource>%s</resource></bind></iq>\n", cookie, nsBind, o.Resource)
+		fmt.Fprintf(StanzaWriter, "<iq type='set' id='%x'><bind xmlns='%s'><resource>%s</resource></bind></iq>\n", cookie, nsBind, o.Resource)
 	}
 	var iq clientIQ
 	if err = c.p.DecodeElement(&iq, nil); err != nil {
@@ -502,11 +503,11 @@ func (c *Client) init(o *Options) error {
 
 	if o.Session {
 		//if server support session, open it
-		fmt.Fprintf(c.conn, "<iq to='%s' type='set' id='%x'><session xmlns='%s'/></iq>", xmlEscape(domain), cookie, nsSession)
+		fmt.Fprintf(StanzaWriter, "<iq to='%s' type='set' id='%x'><session xmlns='%s'/></iq>", xmlEscape(domain), cookie, nsSession)
 	}
 
 	// We're connected and can now receive and send messages.
-	fmt.Fprintf(c.conn, "<presence xml:lang='en'><show>%s</show><status>%s</status></presence>", o.Status, o.StatusMessage)
+	fmt.Fprintf(StanzaWriter, "<presence xml:lang='en'><show>%s</show><status>%s</status></presence>", o.Status, o.StatusMessage)
 
 	return nil
 }
@@ -528,7 +529,7 @@ func (c *Client) startTLSIfRequired(f *streamFeatures, o *Options, domain string
 	}
 	var err error
 
-	fmt.Fprintf(c.conn, "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>\n")
+	fmt.Fprintf(StanzaWriter, "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>\n")
 	var k tlsProceed
 	if err = c.p.DecodeElement(&k, nil); err != nil {
 		return f, errors.New("unmarshal <proceed>: " + err.Error())
@@ -561,11 +562,13 @@ func (c *Client) startTLSIfRequired(f *streamFeatures, o *Options, domain string
 func (c *Client) startStream(o *Options, domain string) (*streamFeatures, error) {
 	if o.Debug {
 		c.p = xml.NewDecoder(tee{c.conn, DebugWriter})
+		StanzaWriter = io.MultiWriter(c.conn, DebugWriter)
 	} else {
 		c.p = xml.NewDecoder(c.conn)
+		StanzaWriter = c.conn
 	}
 
-	_, err := fmt.Fprintf(c.conn, "<?xml version='1.0'?>\n"+
+	_, err := fmt.Fprintf(StanzaWriter, "<?xml version='1.0'?>\n"+
 		"<stream:stream to='%s' xmlns='%s'\n"+
 		" xmlns:stream='%s' version='1.0'>\n",
 		xmlEscape(domain), nsClient, nsStream)
@@ -861,7 +864,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 
 	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'>" + subtext + "<body>%s</body>" + oobtext + thdtext + "</message>"
 
-	return fmt.Fprintf(c.conn, stanza,
+	return fmt.Fprintf(StanzaWriter, stanza,
 		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce(), xmlEscape(chat.Text))
 }
 
@@ -878,17 +881,17 @@ func (c *Client) SendOOB(chat Chat) (n int, err error) {
 		}
 		oobtext += `</x>`
 	}
-	return fmt.Fprintf(c.conn, "<message to='%s' type='%s' id='%s' xml:lang='en'>"+oobtext+thdtext+"</message>",
+	return fmt.Fprintf(StanzaWriter, "<message to='%s' type='%s' id='%s' xml:lang='en'>"+oobtext+thdtext+"</message>",
 		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce())
 }
 
 // SendOrg sends the original text without being wrapped in an XMPP message stanza.
 func (c *Client) SendOrg(org string) (n int, err error) {
-	return fmt.Fprint(c.conn, org)
+	return fmt.Fprint(StanzaWriter, org)
 }
 
 func (c *Client) SendPresence(presence Presence) (n int, err error) {
-	return fmt.Fprintf(c.conn, "<presence from='%s' to='%s'/>", xmlEscape(presence.From), xmlEscape(presence.To))
+	return fmt.Fprintf(StanzaWriter, "<presence from='%s' to='%s'/>", xmlEscape(presence.From), xmlEscape(presence.To))
 }
 
 // SendKeepAlive sends a "whitespace keepalive" as described in chapter 4.6.1 of RFC6120.
@@ -898,7 +901,7 @@ func (c *Client) SendKeepAlive() (n int, err error) {
 
 // SendHtml sends the message as HTML as defined by XEP-0071
 func (c *Client) SendHtml(chat Chat) (n int, err error) {
-	return fmt.Fprintf(c.conn, "<message to='%s' type='%s' xml:lang='en'>"+
+	return fmt.Fprintf(StanzaWriter, "<message to='%s' type='%s' xml:lang='en'>"+
 		"<body>%s</body>"+
 		"<html xmlns='http://jabber.org/protocol/xhtml-im'><body xmlns='http://www.w3.org/1999/xhtml'>%s</body></html></message>",
 		xmlEscape(chat.Remote), xmlEscape(chat.Type), xmlEscape(chat.Text), chat.Text)
@@ -906,7 +909,7 @@ func (c *Client) SendHtml(chat Chat) (n int, err error) {
 
 // Roster asks for the chat roster.
 func (c *Client) Roster() error {
-	fmt.Fprintf(c.conn, "<iq from='%s' type='get' id='roster1'><query xmlns='jabber:iq:roster'/></iq>\n", xmlEscape(c.jid))
+	fmt.Fprintf(StanzaWriter, "<iq from='%s' type='get' id='roster1'><query xmlns='jabber:iq:roster'/></iq>\n", xmlEscape(c.jid))
 	return nil
 }
 

--- a/xmpp_information_query.go
+++ b/xmpp_information_query.go
@@ -19,13 +19,13 @@ func (c *Client) Discovery() (string, error) {
 // RawInformationQuery sends an information query request to the server.
 func (c *Client) RawInformationQuery(from, to, id, iqType, requestNamespace, body string) (string, error) {
 	const xmlIQ = "<iq from='%s' to='%s' id='%s' type='%s'><query xmlns='%s'>%s</query></iq>"
-	_, err := fmt.Fprintf(c.conn, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, requestNamespace, body)
+	_, err := fmt.Fprintf(StanzaWriter, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, requestNamespace, body)
 	return id, err
 }
 
 // rawInformation send a IQ request with the payload body to the server
 func (c *Client) RawInformation(from, to, id, iqType, body string) (string, error) {
 	const xmlIQ = "<iq from='%s' to='%s' id='%s' type='%s'>%s</iq>"
-	_, err := fmt.Fprintf(c.conn, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, body)
+	_, err := fmt.Fprintf(StanzaWriter, xmlIQ, xmlEscape(from), xmlEscape(to), id, iqType, body)
 	return id, err
 }

--- a/xmpp_muc.go
+++ b/xmpp_muc.go
@@ -25,7 +25,7 @@ const (
 
 // Send sends room topic wrapped inside an XMPP message stanza body.
 func (c *Client) SendTopic(chat Chat) (n int, err error) {
-	return fmt.Fprintf(c.conn, "<message to='%s' type='%s' xml:lang='en'>"+"<subject>%s</subject></message>",
+	return fmt.Fprintf(StanzaWriter, "<message to='%s' type='%s' xml:lang='en'>"+"<subject>%s</subject></message>",
 		xmlEscape(chat.Remote), xmlEscape(chat.Type), xmlEscape(chat.Text))
 }
 
@@ -33,7 +33,7 @@ func (c *Client) JoinMUCNoHistory(jid, nick string) (n int, err error) {
 	if nick == "" {
 		nick = c.jid
 	}
-	return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+	return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 		"<x xmlns='%s'>"+
 		"<history maxchars='0'/></x>\n"+
 		"</presence>",
@@ -47,31 +47,31 @@ func (c *Client) JoinMUC(jid, nick string, history_type, history int, history_da
 	}
 	switch history_type {
 	case NoHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s' />\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC)
 	case CharHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<history maxchars='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, history)
 	case StanzaHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<history maxstanzas='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, history)
 	case SecondsHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<history seconds='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, history)
 	case SinceHistory:
 		if history_date != nil {
-			return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+			return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 				"<x xmlns='%s'>\n"+
 				"<history since='%s'/></x>\n"+
 				"</presence>",
@@ -88,28 +88,28 @@ func (c *Client) JoinProtectedMUC(jid, nick string, password string, history_typ
 	}
 	switch history_type {
 	case NoHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>"+
 			"</x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password))
 	case CharHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>\n"+
 			"<history maxchars='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password), history)
 	case StanzaHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>\n"+
 			"<history maxstanzas='%d'/></x>\n"+
 			"</presence>",
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password), history)
 	case SecondsHistory:
-		return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+		return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 			"<x xmlns='%s'>\n"+
 			"<password>%s</password>\n"+
 			"<history seconds='%d'/></x>\n"+
@@ -117,7 +117,7 @@ func (c *Client) JoinProtectedMUC(jid, nick string, password string, history_typ
 			xmlEscape(jid), xmlEscape(nick), nsMUC, xmlEscape(password), history)
 	case SinceHistory:
 		if history_date != nil {
-			return fmt.Fprintf(c.conn, "<presence to='%s/%s'>\n"+
+			return fmt.Fprintf(StanzaWriter, "<presence to='%s/%s'>\n"+
 				"<x xmlns='%s'>\n"+
 				"<password>%s</password>\n"+
 				"<history since='%s'/></x>\n"+
@@ -130,6 +130,6 @@ func (c *Client) JoinProtectedMUC(jid, nick string, password string, history_typ
 
 // xep-0045 7.14
 func (c *Client) LeaveMUC(jid string) (n int, err error) {
-	return fmt.Fprintf(c.conn, "<presence from='%s' to='%s' type='unavailable' />",
+	return fmt.Fprintf(StanzaWriter, "<presence from='%s' to='%s' type='unavailable' />",
 		c.jid, xmlEscape(jid))
 }

--- a/xmpp_ping.go
+++ b/xmpp_ping.go
@@ -11,7 +11,7 @@ func (c *Client) PingC2S(jid, server string) error {
 	if server == "" {
 		server = c.domain
 	}
-	_, err := fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
+	_, err := fmt.Fprintf(StanzaWriter, "<iq from='%s' to='%s' id='c2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",
 		xmlEscape(jid), xmlEscape(server))
@@ -19,7 +19,7 @@ func (c *Client) PingC2S(jid, server string) error {
 }
 
 func (c *Client) PingS2S(fromServer, toServer string) error {
-	_, err := fmt.Fprintf(c.conn, "<iq from='%s' to='%s' id='s2s1' type='get'>\n"+
+	_, err := fmt.Fprintf(StanzaWriter, "<iq from='%s' to='%s' id='s2s1' type='get'>\n"+
 		"<ping xmlns='urn:xmpp:ping'/>\n"+
 		"</iq>",
 		xmlEscape(fromServer), xmlEscape(toServer))
@@ -27,7 +27,7 @@ func (c *Client) PingS2S(fromServer, toServer string) error {
 }
 
 func (c *Client) SendResultPing(id, toServer string) error {
-	_, err := fmt.Fprintf(c.conn, "<iq type='result' to='%s' id='%s'/>",
+	_, err := fmt.Fprintf(StanzaWriter, "<iq type='result' to='%s' id='%s'/>",
 		xmlEscape(toServer), xmlEscape(id))
 	return err
 }

--- a/xmpp_subscription.go
+++ b/xmpp_subscription.go
@@ -5,16 +5,16 @@ import (
 )
 
 func (c *Client) ApproveSubscription(jid string) {
-	fmt.Fprintf(c.conn, "<presence to='%s' type='subscribed'/>",
+	fmt.Fprintf(StanzaWriter, "<presence to='%s' type='subscribed'/>",
 		xmlEscape(jid))
 }
 
 func (c *Client) RevokeSubscription(jid string) {
-	fmt.Fprintf(c.conn, "<presence to='%s' type='unsubscribed'/>",
+	fmt.Fprintf(StanzaWriter, "<presence to='%s' type='unsubscribed'/>",
 		xmlEscape(jid))
 }
 
 func (c *Client) RequestSubscription(jid string) {
-	fmt.Fprintf(c.conn, "<presence to='%s' type='subscribe'/>",
+	fmt.Fprintf(StanzaWriter, "<presence to='%s' type='subscribe'/>",
 		xmlEscape(jid))
 }


### PR DESCRIPTION
When debugging issues it would often be useful to also
see the messages that are sent.
I didn't find a way to do it as simple as you managed 
to do it for received stanzas but from the different
approaches I tried this seems to be the best one.

I purposely didn't enable printing stanzas sent during
auth to prevent people from accidentally pasting their
credentials when showing logs.
