### PR TITLE
DRAFT: fix: When NoTLS is set, don't do StartTLS

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -570,8 +570,11 @@ func (c *Client) init(o *Options) error {
 	}
 
 	// If the server requires STARTTLS, attempt to do so.
-	if f, err = c.startTLSIfRequired(f, o, domain); err != nil {
-		return err
+	// unless the client has specified NoTLS
+	if !o.NoTLS {
+		if f, err = c.startTLSIfRequired(f, o, domain); err != nil {
+			return err
+		}
 	}
 	var mechanism, channelBinding, clientFirstMessage, clientFinalMessageBare, authMessage string
 	var bind2Data, resource, userAgentSW, userAgentDev, userAgentID, fastAuth, saslUpgrade string
@@ -664,7 +667,7 @@ func (c *Client) init(o *Options) error {
 			case slices.Contains(mechSlice, "X-OAUTH2"):
 				mechanism = "X-OAUTH2"
 				// Do not use PLAIN auth if NoPlain is set.
-			case slices.Contains(mechSlice, "PLAIN") && tlsConnOK && !o.NoPLAIN:
+			case slices.Contains(mechSlice, "PLAIN") && (tlsConnOK || o.NoTLS) && !o.NoPLAIN:
 				mechanism = "PLAIN"
 			}
 		}


### PR DESCRIPTION
When using prosody in CI i really want to use plaintext connection. Maybe i should just use random certs and bypass verification but that seemed wrong.

This is the PR that got CI running for matterbridge in https://github.com/matterbridge-org/matterbridge/pull/4

However, i'm not sure if it still applies correctly with the recent updates. I'll come back here once i'm sure.

Also, maybe NoTLS is not the correct option for plaintext auth? It's not clear to me what the mental model of all connection options is in this library. We should probably add docs about the specific order in which they are applied and the option combinations required to reach a server with certain settings.