### PR TITLE
Add XEP 0060 and 0363

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -1510,9 +1510,9 @@ type Chat struct {
 	Text    string
 	Subject string
 	Thread  string
-	Ooburl  string
-	Oobdesc string
-	Lang    string
+	// XEP-0066 Out-Of-Band url/desc
+	Oob  Oob
+	Lang string
 	// Only for incoming messages, ID for outgoing messages will be generated.
 	OriginID string
 	// Only for incoming messages, ID for outgoing messages will be generated.
@@ -1612,6 +1612,7 @@ func (c *Client) Recv() (stanza interface{}, err error) {
 				Lang:      v.Lang,
 				OriginID:  v.OriginID.ID,
 				StanzaID:  v.StanzaID,
+				Oob:       v.Oob,
 			}
 			return chat, nil
 		case *clientQuery:
@@ -1889,10 +1890,10 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	if chat.Thread != `` {
 		thdtext = `<thread>` + xmlEscape(chat.Thread) + `</thread>`
 	}
-	if chat.Ooburl != `` {
-		oobtext = `<x xmlns="jabber:x:oob"><url>` + xmlEscape(chat.Ooburl) + `</url>`
-		if chat.Oobdesc != `` {
-			oobtext += `<desc>` + xmlEscape(chat.Oobdesc) + `</desc>`
+	if chat.Oob.Url != `` {
+		oobtext = `<x xmlns="jabber:x:oob"><url>` + xmlEscape(chat.Oob.Url) + `</url>`
+		if chat.Oob.Desc != `` {
+			oobtext += `<desc>` + xmlEscape(chat.Oob.Desc) + `</desc>`
 		}
 		oobtext += `</x>`
 	}
@@ -1917,10 +1918,10 @@ func (c *Client) SendOOB(chat Chat) (n int, err error) {
 	if chat.Thread != `` {
 		thdtext = `<thread>` + xmlEscape(chat.Thread) + `</thread>`
 	}
-	if chat.Ooburl != `` {
-		oobtext = `<x xmlns="jabber:x:oob"><url>` + xmlEscape(chat.Ooburl) + `</url>`
-		if chat.Oobdesc != `` {
-			oobtext += `<desc>` + xmlEscape(chat.Oobdesc) + `</desc>`
+	if chat.Oob.Url != `` {
+		oobtext = `<x xmlns="jabber:x:oob"><url>` + xmlEscape(chat.Oob.Url) + `</url>`
+		if chat.Oob.Desc != `` {
+			oobtext += `<desc>` + xmlEscape(chat.Oob.Desc) + `</desc>`
 		}
 		oobtext += `</x>`
 	}
@@ -2220,6 +2221,9 @@ type clientMessage struct {
 
 	// Pubsub
 	Event clientPubsubEvent `xml:"event"`
+
+	// XEP-0060 OOB
+	Oob Oob
 
 	// Any hasn't matched element
 	Other []XMLElement `xml:",any"`

--- a/xmpp_http_upload.go
+++ b/xmpp_http_upload.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	XMPPNS_HTTP_UPLOAD = "urn:xmpp:http:upload:0"
+	XMPPNS_X_OOB       = "jabber:x:oob"
 )
 
 type Slot struct {
@@ -31,4 +32,12 @@ type Header struct {
 	XMLName xml.Name `xml:"header"`
 	Name    string   `xml:"name,attr"`
 	Value   string   `xml:",innerxml"`
+}
+
+// Oob is an out-of-band url/description, used in file uploads.
+// See https://xmpp.org/extensions/xep-0066.html
+type Oob struct {
+	XMLName xml.Name `xml:"x,xmlns:jabber:x:oob"`
+	Url     string   `xml:"url"`
+	Desc    string   `xml:"desc"`
 }


### PR DESCRIPTION
This PR adds support for file uploads/downloads by adding upload `Slot` to the `Recv` function as well as typed `Oob` entity so that OOB URLs are parsed on incoming messages too.

I also added a few tests.

I made this PR because i was doing [something like this on matterbridge](https://github.com/matterbridge-org/matterbridge/pull/23) but it was cumbersome, and i thought it would benefit other people as well.

Not implemented here:

- auto-discovery of the file upload component / max upload size
- querying a file upload slot
- uploading the file via HTTP