### PR TITLE
Silence irrelevant gosec messages, for #207

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -49,7 +49,7 @@ import (
 )
 
 // Default TLS configuration options
-var DefaultConfig = &tls.Config{}
+var DefaultConfig = &tls.Config{} //nolint: gosec,G402 // In go1.25 TLS 1.2 used as default. Used by servers for older clients.
 
 // DebugWriter is the writer used to write debugging output to.
 type debugWriter struct {
@@ -1055,7 +1055,7 @@ func (c *Client) init(o *Options) error {
 				storedKey256 := sha256.Sum256(clientKey)
 				storedKey = storedKey256[:]
 			case SCRAM_SHA_1, SCRAM_SHA_1_PLUS:
-				storedKey1 := sha1.Sum(clientKey)
+				storedKey1 := sha1.Sum(clientKey) //nolint: gosec,G401 // Servers use this because of older clients.
 				storedKey = storedKey1[:]
 			}
 			_, err = h.Write([]byte("Server Key"))

--- a/xmpp_avatar.go
+++ b/xmpp_avatar.go
@@ -59,7 +59,7 @@ func handleAvatarData(itemsBody []byte, from, id string) (AvatarData, error) {
 		return AvatarData{}, err
 	}
 
-	hash := sha1.Sum(dataRaw)
+	hash := sha1.Sum(dataRaw) //nolint: gosec,G401 // It is not about security.
 	hashStr := hex.EncodeToString(hash[:])
 	if hashStr != id {
 		return AvatarData{}, errors.New("SHA1 hashes do not match")


### PR DESCRIPTION
These messages will become relevant after about 5-10 years when older clients become vintage and most servers move to TLSv1.3+.`