### PR TITLE
Add support for XEP-0461: Message Replies

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"log"
 	"math/big"
 	"net"
 	"net/http"
@@ -95,11 +94,7 @@ func getCookie() Cookie {
 func getUUID() string {
 	// Use github.com/google/uuid as XEP-0359 requires an UUID according to
 	// RFC 4122.
-	id, err := uuid.NewV7()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return id.String()
+	return uuid.Must(uuid.NewV7()).String()
 }
 
 // Fast holds the XEP-0484 fast token, mechanism and expiry date

--- a/xmpp.go
+++ b/xmpp.go
@@ -1446,7 +1446,7 @@ func (c *Client) IsEncrypted() bool {
 
 // Chat is an incoming or outgoing XMPP chat message.
 type Chat struct {
-	ID      string
+	ID      string   // if unset, will be generated on send
 	Remote  string
 	Type    string
 	Text    string
@@ -1458,10 +1458,9 @@ type Chat struct {
 	Ooburl  string
 	Oobdesc string
 	Lang    string
-	// Only for incoming messages, ID for outgoing messages will be generated.
-	OriginID string
-	// Only for incoming messages, ID for outgoing messages will be generated.
-	StanzaID StanzaID
+	// XEP-0359
+	StanzaID StanzaID // only for incoming messages
+	OriginID string   // if unset, will be generated on send
 	// XEP-0461
 	Reply     *Reply
 	Roster    Roster
@@ -1862,14 +1861,18 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	}
 
 	chat.Text = validUTF8(chat.Text)
-	id := chat.ID
-	if id == "" {
-		id = getUUID()
+
+	if chat.OriginID == "" {
+		chat.OriginID = getUUID()
 	}
+	if chat.ID == "" {
+		chat.ID = chat.OriginID
+	}
+
 	stanza := fmt.Sprintf("<message to='%s' type='%s' id='%s' xml:lang='en'>%s<body>%s</body>"+
 		"%s<origin-id xmlns='%s' id='%s'/>%s%s</message>\n",
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), id, subtext, xmlEscape(chat.Text),
-		replytext, XMPPNS_SID_0, id, oobtext, thdtext)
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), chat.ID, subtext, xmlEscape(chat.Text),
+		replytext, XMPPNS_SID_0, chat.OriginID, oobtext, thdtext)
 	if c.LimitMaxBytes != 0 && len(stanza) > c.LimitMaxBytes {
 		return 0, fmt.Errorf("stanza size (%v bytes) exceeds server limit (%v bytes)",
 			len(stanza), c.LimitMaxBytes)

--- a/xmpp.go
+++ b/xmpp.go
@@ -1463,7 +1463,7 @@ type Chat struct {
 	// Only for incoming messages, ID for outgoing messages will be generated.
 	StanzaID StanzaID
 	// XEP-0461
-	Reply     Reply
+	Reply     *Reply
 	Roster    Roster
 	Other     []string
 	OtherElem []XMLElement
@@ -1853,7 +1853,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	}
 
 	var replytext string
-	if chat.Reply.ID != `` {
+	if chat.Reply != nil {
 		replytext = `<reply id='` + xmlEscape(chat.Reply.ID) + `'`
 		if chat.Reply.To != `` {
 			replytext += ` to='` + xmlEscape(chat.Reply.To) + `'`
@@ -2204,7 +2204,7 @@ type clientMessage struct {
 	StanzaID StanzaID `xml:"stanza-id"`
 
 	// XEP-0461
-	Reply Reply `xml:"reply"`
+	Reply *Reply `xml:"reply"`
 
 	// Pubsub
 	Event clientPubsubEvent `xml:"event"`


### PR DESCRIPTION
[XEP-0461: Message Replies](https://xmpp.org/extensions/xep-0461.html)
We now generate the reply object and correctly attribute author.

I didn't implement [3.1 Compatibility fallback](https://xmpp.org/extensions/xep-0461.html#compat), we're still compliant without but I can look into it soon.